### PR TITLE
Add mdbook-admonish to gh deployment workflow

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install mdbook
         run: |
           mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.35/mdbook-v0.4.35-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo `pwd`/mdbook >> $GITHUB_PATH
       - name: Install mdbook-admonish
         run: |

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -20,6 +20,10 @@ jobs:
           mkdir mdbook
           curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo `pwd`/mdbook >> $GITHUB_PATH
+      - name: Install mdbook-admonish
+        run: |
+          cargo install mdbook-admonish --vers "1.14.0" --locked
+          mdbook-admonish install ./
       - name: Deploy GitHub Pages
         run: |
           mdbook build

--- a/README.md
+++ b/README.md
@@ -2,12 +2,20 @@ This project contains the core of a new introductory guide to Leptos.
 
 It is built using `mdbook`. You can view a local copy by installing `mdbook`
 
-```bash
+```sh
 cargo install mdbook
 ```
 
-and run the book with
+This book also uses an mdbook preprocessor called `mdbook-admonish` to style blocks of text like notes, warnings, etc.
+
+Install mdbook admonish using:
+
+```sh
+cargo install mdbook-admonish
 ```
+
+and then run the book with
+```sh
 mdbook serve
 ```
 


### PR DESCRIPTION
In this commit, I've added support for mdbook-admonish in the gh workflow file, as well as updated the README.md with mdbook-admonish install instructions as well. 