### PR TITLE
Add `.as_ref()` to Params example

### DIFF
--- a/src/router/18_params_and_queries.md
+++ b/src/router/18_params_and_queries.md
@@ -56,7 +56,7 @@ let query = use_query::<ContactSearch>();
 // id: || -> usize
 let id = move || {
 	params.with(|params| {
-		params
+		params.as_ref()
 			.map(|params| params.id)
 			.unwrap_or_default()
 	})


### PR DESCRIPTION
Added `.as_ref()` to make example compile.

I didn't check if the below example

```rust 
let id = move || { params.with(|params| params.get("id").cloned()) };
```

needed an `.as_ref()`, but I don't think it does.