### PR TITLE
Fix TOML syntax for helix editor in DX chapter

### DIFF
--- a/src/getting_started/leptos_dx.md
+++ b/src/getting_started/leptos_dx.md
@@ -60,9 +60,7 @@ config = { procMacro = { ignored =
           # Optional:
           # "component",
           "server"
-        ]
-    }
-} }
+        ] } } }
 ```
 
 ```admonish info


### PR DESCRIPTION
This is a tiny commit which fixes the TOML syntax in the DX chapter for the Helix text editor. 

This should make it easier to copy-and-paste directly from the book