### PR TITLE
remove note about Trunk bug - fixed in Trunk v0.18.x

### DIFF
--- a/src/getting_started/README.md
+++ b/src/getting_started/README.md
@@ -117,8 +117,6 @@ Trunk should automatically compile your app and open it in your default browser.
 If you make edits to `main.rs`, Trunk will recompile your source code and
 live-reload the page.
 
-> Due to an upstream [issue](https://github.com/thedodd/trunk/issues/597), `trunk` v0.17.5 will not work with live-reload on Windows. Use `trunk` v0.17.3 or [`trunk-ng`](https://github.com/thedodd/trunk/issues/597#issuecomment-1772944469) as a temporary workaround.
-
 Welcome to the world of UI development with Rust and WebAssembly (WASM), powered by Leptos and Trunk!
 
 ---


### PR DESCRIPTION
with the change in repo ownership of Trunk, fixes have started being merged again. 

with the new, v0.18.x release of Trunk, the bug referenced in the Leptos book note has been fixed.

this commit fixes: https://github.com/leptos-rs/book/issues/17

see:
https://github.com/trunk-rs/trunk/issues/597#issuecomment-1853467472