### PR TITLE
Clarify interchangeability between signals and closure wrapped functions

### DIFF
--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -111,7 +111,8 @@ to our view:
 ```rust
 <progress
     max="50"
-    // signals are functions, so this <=> `move || count.get()`
+    // signals are functions, so `value=count` and `value=move || count.get()`
+    // are interchangeable.
     value=count
 />
 ```


### PR DESCRIPTION
Expanded on the phrase "signals are functions, so this <=> `move || count.get()`" to eliminate the uncommon `<=>` notation.

I see that this PR may conflict with #25. If that's a problem I will gladly rebase my repo and update this PR.