### PR TITLE
Demonstrate Dynamic Styles

### DIFF
--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -86,15 +86,33 @@ class=("button-20", move || count() % 2 == 1)
 Individual CSS properties can be directly updated with a similar `style:` syntax.
 
 ```rust
+// Signals holding dynamic data
 let (x, set_x) = create_signal(0);
 let (y, set_y) = create_signal(0);
 view! {
+
+    // Buttons updating dynamic data
+    <button
+        on:click={move |_| {
+            set_x.update(|n| *n += 10);
+        }}
+    >
+        "Move x!"
+    </button>
+    <button
+        on:click={move |_| {
+            set_y.update(|n| *n += 10);
+        }}
+    >
+        "Move y!"
+    </button>
+
+    // Dynamic Styles
     <div
         style="position: absolute"
         style:left=move || format!("{}px", x() + 100)
         style:top=move || format!("{}px", y() + 100)
         style:background-color=move || format!("rgb({}, {}, 100)", x(), y())
-        style=("--columns", x)
     >
         "Moves when coordinates change"
     </div>

--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -111,7 +111,8 @@ to our view:
 ```rust
 <progress
     max="50"
-    // signals are functions, so this <=> `move || count.get()`
+    // signals are functions, so `value=count` and `value=move || count.get()`
+    // are interchangeable.
     value=count
 />
 ```

--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -86,37 +86,23 @@ class=("button-20", move || count() % 2 == 1)
 Individual CSS properties can be directly updated with a similar `style:` syntax.
 
 ```rust
-// Signals holding dynamic data
-let (x, set_x) = create_signal(0);
-let (y, set_y) = create_signal(0);
-view! {
-
-    // Buttons updating dynamic data
-    <button
-        on:click={move |_| {
-            set_x.update(|n| *n += 10);
-        }}
-    >
-        "Move x!"
-    </button>
-    <button
-        on:click={move |_| {
-            set_y.update(|n| *n += 10);
-        }}
-    >
-        "Move y!"
-    </button>
-
-    // Dynamic Styles
-    <div
-        style="position: absolute"
-        style:left=move || format!("{}px", x() + 100)
-        style:top=move || format!("{}px", y() + 100)
-        style:background-color=move || format!("rgb({}, {}, 100)", x(), y())
-    >
-        "Moves when coordinates change"
-    </div>
-}
+    let (x, set_x) = create_signal(0);
+        view! {
+            <button
+                on:click={move |_| {
+                    set_x.update(|n| *n += 10);
+                }}
+                // Leptos adds these to a single html style attribute
+                style="position: absolute"
+                style:left=move || format!("{}px", x() + 100)
+                style:background-color=move || format!("rgb({}, {}, 100)", x(), 100)
+                style:max-width="400px"
+                // Set a CSS variable for stylesheet use
+                style=("--columns", x)
+            >
+                "Click to Move"
+            </button>
+    }
 ```
 
 ## Dynamic Attributes

--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -92,8 +92,9 @@ Individual CSS properties can be directly updated with a similar `style:` syntax
                 on:click={move |_| {
                     set_x.update(|n| *n += 10);
                 }}
-                // Leptos adds these to a single html style attribute
+                // set the `style` attribute
                 style="position: absolute"
+                // and toggle individual CSS properties with `style:`
                 style:left=move || format!("{}px", x() + 100)
                 style:background-color=move || format!("rgb({}, {}, 100)", x(), 100)
                 style:max-width="400px"


### PR DESCRIPTION
Changes allow demonstration of the Dynamic Styles code.
It's important (imo) that docs allow readers to put the covered concepts into practice in their own environments. This is the only way they can "know" that covered material works for them.

Two changes:

1. Added buttons to exercise code showing dynamic styles. Increment vaules in steps of 10 to make motion more obvious.

2. Remove "columns" style. The syntax provided doesn't work. The concept is not really applicable to the example (imo).