### PR TITLE
fix: use real `leptos` API in example.

### DIFF
--- a/src/reactivity/14_create_effect.md
+++ b/src/reactivity/14_create_effect.md
@@ -102,7 +102,8 @@ This works because the framework essentially creates an effect wrapping this upd
 let (count, set_count) = create_signal(0);
 
 // create a DOM element
-let p = create_element("p");
+let document = leptos::document();
+let p = document.create_element("p").unwrap();
 
 // create an effect to reactively update the text
 create_effect(move |prev_value| {


### PR DESCRIPTION
This example previously caused someone to go searching for the `create_element` function. This change tries to mimic the actual leptos API by calling `leptos::document` prior. 