### PR TITLE
Fix misnamed prop in section 3.3

### DIFF
--- a/src/view/03_components.md
+++ b/src/view/03_components.md
@@ -130,8 +130,8 @@ fn ProgressBar(
 }
 ```
 
-Now, we can use `<ProgressBar max=50 value=count/>`, or we can omit `max`
-to use the default value (i.e., `<ProgressBar value=count/>`). The default value
+Now, we can use `<ProgressBar max=50 progress=count/>`, or we can omit `max`
+to use the default value (i.e., `<ProgressBar progress=count/>`). The default value
 on an `optional` is its `Default::default()` value, which for a `u16` is going to
 be `0`. In the case of a progress bar, a max value of `0` is not very useful.
 


### PR DESCRIPTION
I'm reading the Leptos book and stumbled across a minor typo in section 3.3. Thought I'd submit a quick pull request to get it fixed!

I've been keeping tabs on Leptos for a while (really enthusiastic about this web framework!) but this is my first time actually learning to use it for myself, or contributing to the project. I'm not a very experienced Rust programmer but I am an experienced proofreader, so if I find any additional typos during my read-through of the book I'll try to send more of these!