### PR TITLE
fix: 3.2 Dynamic Attributes CodeSandbox demo code

### DIFF
--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -186,9 +186,9 @@ for expensive calculations.
 >
 > [Click here for the full `view` macros docs](https://docs.rs/leptos/latest/leptos/macro.view.html).
 
-[Click to open CodeSandbox.](https://codesandbox.io/p/sandbox/2-dynamic-attributes-0-5-lwdrpm?file=%2Fsrc%2Fmain.rs%3A1%2C1)
+[Click to open CodeSandbox.](https://codesandbox.io/p/devbox/2-dynamic-attributes-0-5-forked-6zrss7?file=%2Fsrc%2Fmain.rs%3A7%2C68)
 
-<iframe src="https://codesandbox.io/p/sandbox/2-dynamic-attributes-0-5-lwdrpm?file=%2Fsrc%2Fmain.rs%3A1%2C1" width="100%" height="1000px" style="max-height: 100vh"></iframe>
+<iframe src="https://codesandbox.io/p/devbox/2-dynamic-attributes-0-5-forked-6zrss7?file=%2Fsrc%2Fmain.rs%3A7%2C68" width="100%" height="1000px" style="max-height: 100vh"></iframe>
 
 <details>
 <summary>CodeSandbox Source</summary>


### PR DESCRIPTION
### Description
This PR fixes the button text not turning red on odd counts by adding the missing CSS style in index.html and provides a new CodeSandbox link.

### Changes
1, Updated CodeSandbox link
2, Added the missing .red style in index.html
```
.red {
    color: red;
}
```

### Questions
1. **What change does your PR introduce?**
   - [x] Bugfix
   - [ ] New Feature
   - [ ] Enhancement
   - [ ] Refactoring
   - [x] Documentation Update
   - [ ] Other

2. **Is this PR related to any open issues?**
   - [x] Yes ([40](https://github.com/leptos-rs/book/issues/40))
   - [ ] No
