### PR TITLE
fixing fn tab after Passing Server Children to Islands heading to if …

### DIFF
--- a/src/islands.md
+++ b/src/islands.md
@@ -351,7 +351,7 @@ And let’s modify the `Tab` island to use that context to show or hide itself:
 fn Tab(children: Children) -> impl IntoView {
     let selected = expect_context::<ReadSignal<usize>>();
     view! {
-        <div style:display=move || if selected() {
+        <div style:display=move || if selected() == index {
             "block"
         } else {
             "none"


### PR DESCRIPTION
New Code: "selected()==index"

This replaces ... "selected()" in the 2nd code block after the chapter heading: "Passing Server Children to Islands".
The new code is already present in the complete code solution further down the page, but for people like me who try coding up block by block, this fix will make such progressions less painful.