### PR TITLE
Add documentation for how to deploy to Railway

### DIFF
--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -72,11 +72,10 @@ FROM rustlang/rust:nightly-alpine as builder
 
 RUN apk update && \
     apk add --no-cache bash curl npm libc-dev binaryen
-    # protoc openssl-dev protobuf-dev gcc git g++ libc-dev make binaryen
 
 RUN npm install -g sass
 
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/leptos-rs/cargo-leptos/releases/download/0.2.5/cargo-leptos-installer.sh | sh
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/leptos-rs/cargo-leptos/releases/latest/download/cargo-leptos-installer.sh | sh
 
 # Add the WASM target
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
This uses a Railway template I created to save users time. I also added an alpine based dockerfile, as the debian based one was not working for me.

I didn't want to just outright delete/update it, maybe this was just me doing things wrong. But the docker file I added I can confirm works well. And using the GitHub release install script was much faster than cargo binstall