### PR TITLE
Dev Container Implementation and README.md Updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,53 +1,10 @@
-FROM debian:bookworm
+FROM rust:1.75.0
 
-# Locked versions
-ARG RUST_VERSION_FULL=1.75.0 \
-    MDBOOK_VERSION=0.4.* \
-    MDBOOK_ADMONISH_VERSION=1.*
-
-# Update package repositories and existing packages
-RUN apt update && \
-    apt upgrade -y
-
-# Install basic apt packages
-RUN apt install -y \
-    git \
-    curl \
-    gnupg \
-    lsb-release \
-    zsh \
-    build-essential
-
-# Install Docker with socket mounted from host
-# Since this is just a Dev Container, mounting the root socket will be safe
-ENV DOCKER_HOST=unix:///var/run/docker-host.sock
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt update && \
-    apt install -y docker-ce docker-ce-cli containerd.io && \
-    if getent group docker > /dev/null 2>&1; then \
-    echo "Docker group exists"; \
-    else \
-    groupadd docker; \
-    fi && \
-    usermod -aG docker root
-
-# Install Zsh with Oh My Zsh with plugins and set as default shell
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" --unattended && \
-    git clone https://github.com/zsh-users/zsh-autosuggestions $HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting $HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && \
-    git clone https://github.com/zsh-users/zsh-history-substring-search $HOME/.oh-my-zsh/custom/plugins/zsh-history-substring-search && \
-    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions zsh-syntax-highlighting zsh-history-substring-search history aliases sudo themes docker nmap kubectl)/' $HOME/.zshrc && \
-    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="af-magic"/' $HOME/.zshrc && \
-    chsh -s /usr/bin/zsh
-
-# Install Rust with targets and CLI tools
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION_FULL} && \
-    rustup component add rustfmt clippy && \
-    cargo install mdbook --version ${MDBOOK_VERSION} && \
-    cargo install mdbook-admonish --version ${MDBOOK_ADMONISH_VERSION}
-
+# Install MDBook and other CLI tools
+RUN rustup component add rustfmt clippy && \
+    cargo install mdbook --version 0.4.* && \
+    cargo install mdbook-admonish --version 1.*
+    
 # Tell git to trust "dubious" ownership
 RUN git config --global --add safe.directory /repository
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,57 @@
+FROM debian:bookworm
+
+# Locked versions
+ARG RUST_VERSION_FULL=1.75.0 \
+    CARGO_WATCH_VERSION=8.* \
+    MDBOOK_VERSION=0.4.* \
+    MDBOOK_ADMONISH_VERSION=1.*
+
+# Update package repositories and existing packages
+RUN apt update && \
+    apt upgrade -y
+
+# Install basic apt packages
+RUN apt install -y \
+    git \
+    curl \
+    gnupg \
+    lsb-release \
+    zsh \
+    build-essential
+
+# Install Docker with socket mounted from host
+# Since this is just a Dev Container, mounting the root socket will be safe
+ENV DOCKER_HOST=unix:///var/run/docker-host.sock
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt update && \
+    apt install -y docker-ce docker-ce-cli containerd.io && \
+    if getent group docker > /dev/null 2>&1; then \
+    echo "Docker group exists"; \
+    else \
+    groupadd docker; \
+    fi && \
+    usermod -aG docker root
+
+# Install Zsh with Oh My Zsh with plugins and set as default shell
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" --unattended && \
+    git clone https://github.com/zsh-users/zsh-autosuggestions $HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions && \
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting $HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && \
+    git clone https://github.com/zsh-users/zsh-history-substring-search $HOME/.oh-my-zsh/custom/plugins/zsh-history-substring-search && \
+    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions zsh-syntax-highlighting zsh-history-substring-search history aliases sudo themes docker nmap kubectl)/' $HOME/.zshrc && \
+    sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="af-magic"/' $HOME/.zshrc && \
+    chsh -s /usr/bin/zsh
+
+# Install Rust with targets and CLI tools
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION_FULL} && \
+    rustup component add rustfmt clippy && \
+    cargo install cargo-watch --version ${CARGO_WATCH_VERSION} && \
+    cargo install mdbook --version ${MDBOOK_VERSION} && \
+    cargo install mdbook-admonish --version ${MDBOOK_ADMONISH_VERSION}
+
+# Tell git to trust "dubious" ownership
+RUN git config --global --add safe.directory /repository
+
+# Entry directory for non-vscode containers based on this image
+WORKDIR /repository

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:bookworm
 
 # Locked versions
 ARG RUST_VERSION_FULL=1.75.0 \
-    CARGO_WATCH_VERSION=8.* \
     MDBOOK_VERSION=0.4.* \
     MDBOOK_ADMONISH_VERSION=1.*
 
@@ -46,7 +45,6 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION_FULL} && \
     rustup component add rustfmt clippy && \
-    cargo install cargo-watch --version ${CARGO_WATCH_VERSION} && \
     cargo install mdbook --version ${MDBOOK_VERSION} && \
     cargo install mdbook-admonish --version ${MDBOOK_ADMONISH_VERSION}
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75.0
+FROM rust:1
 
 # Install MDBook and other CLI tools
 RUN rustup component add rustfmt clippy && \

--- a/.devcontainer/book.sh
+++ b/.devcontainer/book.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script is executed from the root of the repository in the book container.
+
+# Serve the MDBook
+mdbook serve -n 0.0.0.0 -p 3000

--- a/.devcontainer/book.sh
+++ b/.devcontainer/book.sh
@@ -2,4 +2,4 @@
 # This script is executed from the root of the repository in the book container.
 
 # Serve the MDBook
-mdbook serve -n 0.0.0.0 -p 3000
+mdbook serve -n '0.0.0.0' -p '3000'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,12 @@
         // Github
         "github.vscode-pull-request-github",
         // Prettier
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        // Rust
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        // TOML Highlighting
+        "tamasfe.even-better-toml"
       ],
       "settings": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Leptos Book",
+  "dockerComposeFile": ["docker-compose.yml"],
+  "service": "devcontainer",
+  "workspaceFolder": "/repository",
+  "shutdownAction": "stopCompose",
+  "initializeCommand": "echo 'Starting devcontainer...'",
+  "forwardPorts": ["book:3000"],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Docker
+        "ms-azuretools.vscode-docker",
+        // Copilot
+        "github.copilot",
+        "github.copilot-chat",
+        // Github
+        "github.vscode-pull-request-github",
+        // Prettier
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.formatOnPaste": true,
+        "editor.tabSize": 4
+      }
+    }
+  },
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,9 @@
         "rust-lang.rust-analyzer",
         "vadimcn.vscode-lldb",
         // TOML Highlighting
-        "tamasfe.even-better-toml"
+        "tamasfe.even-better-toml",
+        // Markdown Tools
+        "yzhang.markdown-all-in-one"
       ],
       "settings": {
         "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+name: leptos-book
+
+services:
+  devcontainer:
+    build:
+      context: ./..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ./..:/repository
+    # VSCode needs a second to be able to attach to the container
+    command: /bin/sh -c "while sleep 1000; do :; done"
+
+  book:
+    build:
+      context: ./../
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ./..:/repository
+    expose:
+      - 3000
+    # Run the book
+    command: .devcontainer/book.sh

--- a/README.md
+++ b/README.md
@@ -13,18 +13,6 @@ You can find the live version of this book on the [Leptos Website](https://book.
 
 ## Building the Book
 
-### VSCode Dev Container
-
-The easiest way to build the book is to use the included [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/containers). This will automatically install all dependencies, build the book, and serve it at [`http://localhost:3000`](http://localhost:3000) with live reloading for your convenience.
-
-Simply open the repository in VSCode and click the "Reopen in Container" button in the bottom right corner of the window when VSCode loads. You will need to have [Docker](https://www.docker.com/) installed for this to work and you will also need to install the official [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
-
-### Manual Build
-
-If you don't want to use the Dev Container, you can build the book manually. You must have Rust installed to do this.
-
-#### Installing Dependencies
-
 It is built using [`mdbook`](https://crates.io/crates/mdbook). You can view a local copy by installing `mdbook` with Cargo.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ mdbook serve
 ```
 
 It should now be available at [`http://localhost:3000`](http://localhost:3000).
+
+## Optional: VSCode Dev Container
+
+You can optionally build and run it in the example [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), which will automatically install all dependencies, build the book, and serve it at [`http://localhost:3000`](http://localhost:3000) with live reloading.
+
+Install Docker and the official [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension, then open the project in VSCode and "Reopen in dev container" when prompted.
+
+For more info, see: https://code.visualstudio.com/remote/advancedcontainers/use-docker-kubernetes
+
+To run Docker commands inside the dev container, see: https://code.visualstudio.com/remote/advancedcontainers/use-docker-kubernetes

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can find the live version of this book on the [Leptos Website](https://book.
 
 ### VSCode Dev Container
 
-The easiest way to build the book is to use the included [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/containers). This will automatically install all dependencies, build the book, and serve it at [`http://localhost:3000`](http://localhost:3000) with live reloading for your convinience.
+The easiest way to build the book is to use the included [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/containers). This will automatically install all dependencies, build the book, and serve it at [`http://localhost:3000`](http://localhost:3000) with live reloading for your convenience.
 
 Simply open the repository in VSCode and click the "Reopen in Container" button in the bottom right corner of the window when VSCode loads. You will need to have [Docker](https://www.docker.com/) installed for this to work and you will also need to install the official [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 - [Leptos Book](#leptos-book)
   - [Introduction](#introduction)
   - [Building the Book](#building-the-book)
-    - [VSCode Dev Container](#vscode-dev-container)
-    - [Manual Build](#manual-build)
-      - [Installing Dependencies](#installing-dependencies)
-      - [Building the Book](#building-the-book-1)
+  - [Optional: VSCode Dev Container](#vscode-dev-container)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,51 @@
-This project contains the core of a new introductory guide to Leptos.
+# Leptos Book
 
-It is built using `mdbook`. You can view a local copy by installing `mdbook`
+- [Leptos Book](#leptos-book)
+  - [Introduction](#introduction)
+  - [Building the Book](#building-the-book)
+    - [VSCode Dev Container](#vscode-dev-container)
+    - [Manual Build](#manual-build)
+      - [Installing Dependencies](#installing-dependencies)
+      - [Building the Book](#building-the-book-1)
+
+## Introduction
+
+This project contains the core of a new introductory guide to Leptos. Pull requests for any typos, clarification, or improvements are always welcome.
+
+You can find the live version of this book on the [Leptos Website](https://book.leptos.dev/).
+
+## Building the Book
+
+### VSCode Dev Container
+
+The easiest way to build the book is to use the included [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/containers). This will automatically install all dependencies, build the book, and serve it at [`http://localhost:3000`](http://localhost:3000) with live reloading for your convinience.
+
+Simply open the repository in VSCode and click the "Reopen in Container" button in the bottom right corner of the window when VSCode loads. You will need to have [Docker](https://www.docker.com/) installed for this to work and you will also need to install the official [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+
+### Manual Build
+
+If you don't want to use the Dev Container, you can build the book manually. You must have Rust installed to do this.
+
+#### Installing Dependencies
+
+It is built using [`mdbook`](https://crates.io/crates/mdbook). You can view a local copy by installing `mdbook` with Cargo.
 
 ```sh
-cargo install mdbook
+cargo install mdbook --version 0.4.*
 ```
 
-This book also uses an mdbook preprocessor called `mdbook-admonish` to style blocks of text like notes, warnings, etc.
-
-Install mdbook admonish using:
+This book also uses an mdbook preprocessor called [`mdbook-admonish`](https://crates.io/crates/mdbook-admonish) to style blocks of text like notes, warnings, etc.
 
 ```sh
-cargo install mdbook-admonish
+cargo install mdbook-admonish --version 1.*
 ```
 
-and then run the book with
+#### Building the Book
+
+You can now build the book with live reloading by running the following command in the root of the repository.
+
 ```sh
 mdbook serve
 ```
 
-It should be available at `http://localhost:3000`.
-
+It should now be available at [`http://localhost:3000`](http://localhost:3000).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This book also uses an mdbook preprocessor called [`mdbook-admonish`](https://cr
 cargo install mdbook-admonish --version 1.*
 ```
 
-#### Building the Book
 
 You can now build the book with live reloading by running the following command in the root of the repository.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cargo install mdbook-admonish --version 1.*
 ```
 
 
-You can now build the book with live reloading by running the following command in the root of the repository.
+and then run the book with
 
 ```sh
 mdbook serve


### PR DESCRIPTION
This PR adds an optional [VSCode Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) with [Docker](https://www.docker.com/) for a concise, easily rebuildable environment.

It also updates the main `README.md` file of the repository to reflect this addition with instructions. Please read the new updated `README.md` for more information and try out this addition.