### PR TITLE
Use a base OS to run binary instead of Rust runtime

### DIFF
--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -43,7 +43,13 @@ COPY . .
 # Build the app
 RUN cargo leptos build --release -vv
 
-FROM rustlang/rust:nightly-bullseye as runner
+FROM debian:bookworm-slim as runtime
+WORKDIR /app
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # -- NB: update binary name from "leptos_start" to match your app name in Cargo.toml --
 # Copy the server binary to the /app directory
@@ -51,9 +57,9 @@ COPY --from=builder /app/target/release/leptos_start /app/
 
 # /target/site contains our JS/WASM/CSS, etc.
 COPY --from=builder /app/target/site /app/site
+
 # Copy Cargo.toml if it’s needed at runtime
 COPY --from=builder /app/Cargo.toml /app/
-WORKDIR /app
 
 # Set any required env variables and
 ENV RUST_LOG="info"


### PR DESCRIPTION
The Rust runtime for a docker image is large as it includes the language's tooling. It is not needed to run a Rust binary file. This replaces the full runtime with a base OS (Debian) in order to reduce the size of the Docker image. As an example, this reduced the Docker image size of my website from ~2GB to ~100MB.

This is adapted from the [zero2prod](https://github.com/LukeMathWalker/zero-to-production/blob/main/Dockerfile) Dockerfile.

I am not sure if installing 'openssl' and 'ca-certificates' is strictly required, but since the intention of this Dockerfile is to create a Docker image for a web app, and the basis for the update is from a book on Rust web apps, I thought it made sense to leave in. Open to any thoughts on that. Many thanks.