### PR TITLE
Add mdbook config entries to link users to this repo

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,6 @@
 [output.html]
 additional-css = ["./mdbook-admonish.css"]
+git-repository-url = "https://github.com/leptos-rs/book"
 [output.html.playground]
 runnable = false
 

--- a/book.toml
+++ b/book.toml
@@ -1,6 +1,7 @@
 [output.html]
 additional-css = ["./mdbook-admonish.css"]
 git-repository-url = "https://github.com/leptos-rs/book"
+edit-url-template = "https://github.com/leptos-rs/book/edit/main/{path}"
 [output.html.playground]
 runnable = false
 


### PR DESCRIPTION
Basically what the title says, there are two config options `output.html.git-repository-url` and `output.html.edit-url-template`.
The first one adds a link to the repo the book is developed from and is in my opinion essential.
The second one adds a link to edit the current page and would be nice to have. \
(Split into two commits for maintainer convinience.)

An example how both look like/work would be the [mdBook Documentation](https://rust-lang.github.io/mdBook/).
