### PR TITLE
Update Helix languages.toml snippet in leptos_dx.md

### DIFF
--- a/src/getting_started/leptos_dx.md
+++ b/src/getting_started/leptos_dx.md
@@ -67,13 +67,11 @@ Helix, in `.helix/languages.toml`:
 name = "rust"
 
 [language-server.rust-analyzer]
-config = { procMacro = { ignored =
-    { leptos_macro =
-        [
-          # Optional:
-          # "component",
-          "server"
-        ] } } }
+config = { procMacro = { ignored = { leptos_macro = [
+	# Optional:
+	# "component",
+	"server"
+] } } }
 ```
 
 ## 3) Set up `leptosfmt` With Rust Analyzer (optional)


### PR DESCRIPTION
Currently, the snippet results in a parsing error when opening Helix.