### PR TITLE
Added SSR feature in rust-analyzer getting started.

### DIFF
--- a/src/getting_started/leptos_dx.md
+++ b/src/getting_started/leptos_dx.md
@@ -38,6 +38,18 @@ VSCode `settings.json`:
 }
 ```
 
+VSCode with cargo-leptos `settings.json`:
+```json
+"rust-analyzer.procMacro.ignored": {
+	"leptos_macro": [
+        // optional:
+		// "component",
+		"server"
+	],
+},
+"rust-analyzer.cargo.features": ["ssr"]
+```
+
 neovim with lspconfig:
 
 ```lua


### PR DESCRIPTION
without this rust-analyzer won't give suggestions for any crates in the ssr feature due to the optional flag being true.

Had this issue my self and took a while to figure out.