### PR TITLE
Add custom admonition for code sandbox

### DIFF
--- a/CodeSandbox-Square-Logo.svg
+++ b/CodeSandbox-Square-Logo.svg
@@ -1,0 +1,3 @@
+<svg width="600" height="600" viewBox="0 0 600 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M150 150L449.832 150V450H150V150ZM419.168 180.682V419.318H180.665V180.682H419.168Z" fill="#151515"/>
+</svg>

--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,10 @@
 [output.html]
-additional-css = ["./mdbook-admonish.css"]
+additional-css = [
+    "./mdbook-admonish.css",
+    "./mdbook-admonish-custom.css",
+    "./sandbox.css",
+]
+additional-js = ["./sandbox.js"]
 git-repository-url = "https://github.com/leptos-rs/book"
 edit-url-template = "https://github.com/leptos-rs/book/edit/main/{path}"
 [output.html.playground]
@@ -9,4 +14,9 @@ runnable = false
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "3.0.1" # do not edit: managed by `mdbook-admonish install`
+assets_version = "3.0.1"    # do not edit: managed by `mdbook-admonish install`
+
+[[preprocessor.admonish.custom]]
+directive = "sandbox"
+color = "#DCFF50"
+icon = "./CodeSandbox-Square-Logo.svg"

--- a/mdbook-admonish-custom.css
+++ b/mdbook-admonish-custom.css
@@ -1,0 +1,20 @@
+:root {
+  --md-admonition-icon--admonish-sandbox: url("data:image/svg+xml;charset=utf-8,<svg width='600' height='600' viewBox='0 0 600 600' fill='none' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M150 150L449.832 150V450H150V150ZM419.168 180.682V419.318H180.665V180.682H419.168Z' fill='%23151515'/></svg>");
+}
+
+:is(.admonition):is(.admonish-sandbox) {
+  border-color: #dcff50;
+}
+
+:is(.admonish-sandbox) > :is(.admonition-title, summary.admonition-title) {
+  background-color: rgba(220, 255, 80, 0.1);
+}
+:is(.admonish-sandbox) > :is(.admonition-title, summary.admonition-title)::before {
+  background-color: #dcff50;
+  mask-image: var(--md-admonition-icon--admonish-sandbox);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-sandbox);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}

--- a/sandbox.css
+++ b/sandbox.css
@@ -7,17 +7,21 @@
     box-sizing: border-box;
 }
 
-:is(.admonition):is(.admonish-sandbox):is([open]) {
-    --sandbox-width: calc(
-        100vw - var(--sidebar-width) - calc(var(--page-padding) + 1.2rem) * 2 -
-            6px - 4px
-    );
+@media only screen and (min-width: 1081px) {
+    :is(.admonition):is(.admonish-sandbox):is([open]) {
+        --sandbox-width: calc(
+            100vw - var(--sidebar-width) -
+                calc(var(--page-padding) + 1.2rem + 90px) * 2 - 6px - 4px
+        );
 
-    width: var(--sandbox-width);
-    margin-left: calc(calc(var(--sandbox-width) - 100%) / 2 * -1);
-    z-index: 10;
-}
+        width: var(--sandbox-width);
+        margin-left: calc(calc(var(--sandbox-width) - 100%) / 2 * -1);
+        z-index: 10;
+    }
 
-body.sidebar-hidden :is(.admonition):is(.admonish-sandbox):is([open]) {
-    --sandbox-width: calc(100vw - calc(var(--page-padding) + 1.2rem) * 2 - 4px);
+    body.sidebar-hidden :is(.admonition):is(.admonish-sandbox):is([open]) {
+        --sandbox-width: calc(
+            100vw - calc(var(--page-padding) + 1.2rem + 90px) * 2 - 4px
+        );
+    }
 }

--- a/sandbox.css
+++ b/sandbox.css
@@ -1,0 +1,23 @@
+:is(.admonition):is(.admonish-sandbox) {
+    transition-property: width, margin-left;
+    transition-duration: 300ms;
+    transition-timing-function: ease-out;
+    margin-left: 0;
+    position: relative;
+    box-sizing: border-box;
+}
+
+:is(.admonition):is(.admonish-sandbox):is([open]) {
+    --sandbox-width: calc(
+        100vw - var(--sidebar-width) - calc(var(--page-padding) + 1.2rem) * 2 -
+            6px - 4px
+    );
+
+    width: var(--sandbox-width);
+    margin-left: calc(calc(var(--sandbox-width) - 100%) / 2 * -1);
+    z-index: 10;
+}
+
+body.sidebar-hidden :is(.admonition):is(.admonish-sandbox):is([open]) {
+    --sandbox-width: calc(100vw - calc(var(--page-padding) + 1.2rem) * 2 - 4px);
+}

--- a/sandbox.js
+++ b/sandbox.js
@@ -1,0 +1,13 @@
+(() => {
+  const boxes = document.querySelectorAll("details.admonish-sandbox");
+  boxes.forEach((box) => {
+    const once = () => {
+      const template = box.querySelector("template");
+      const sandbox = template.content.cloneNode(true);
+      template.after(sandbox);
+
+      box.removeEventListener("toggle", once);
+    };
+    box.addEventListener("toggle", once);
+  });
+})();

--- a/src/view/01_basic_component.md
+++ b/src/view/01_basic_component.md
@@ -157,9 +157,19 @@ You can see here that while `set_count` just sets the value, `set_count.update()
 Other Previews > 8080.` Hover over any of the variables to show Rust-Analyzer details
 > and docs for what’s going on. Feel free to fork the examples to play with them yourself!
 
+```admonish sandbox title="Live example" collapsible=true
+
 [Click to open CodeSandbox.](https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1)
 
-<iframe src="https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1" width="100%" height="1000px" style="max-height: 100vh"></iframe>
+<noscript>
+  Please enable JavaScript to view examples.
+</noscript>
+
+<template>
+  <iframe src="https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1" width="100%" height="1000px" style="max-height: 100vh"></iframe>
+</template>
+
+```
 
 <details>
 <summary>CodeSandbox Source</summary>

--- a/src/view/01_basic_component.md
+++ b/src/view/01_basic_component.md
@@ -3,6 +3,25 @@
 That “Hello, world!” was a _very_ simple example. Let’s move on to something a
 little more like an ordinary app.
 
+> Throughout this tutorial, we’ll use CodeSandbox to show interactive examples. To
+> show the browser in the sandbox, you may need to click `Add DevTools >
+Other Previews > 8080.` Hover over any of the variables to show Rust-Analyzer details
+> and docs for what’s going on. Feel free to fork the examples to play with them yourself!
+
+```admonish sandbox title="Live example" collapsible=true
+
+[Click to open CodeSandbox.](https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1)
+
+<noscript>
+  Please enable JavaScript to view examples.
+</noscript>
+
+<template>
+  <iframe src="https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1" width="100%" height="1000px" style="max-height: 100vh"></iframe>
+</template>
+
+```
+
 First, let’s edit the `main` function so that, instead of rendering the whole
 app, it just renders an `<App/>` component. Components are the basic unit of
 composition and design in most web frameworks, and Leptos is no exception.
@@ -151,25 +170,6 @@ move |_| {
 ```
 
 You can see here that while `set_count` just sets the value, `set_count.update()` gives us a mutable reference and mutates the value in place. Either one will trigger a reactive update in our UI.
-
-> Throughout this tutorial, we’ll use CodeSandbox to show interactive examples. To
-> show the browser in the sandbox, you may need to click `Add DevTools >
-Other Previews > 8080.` Hover over any of the variables to show Rust-Analyzer details
-> and docs for what’s going on. Feel free to fork the examples to play with them yourself!
-
-```admonish sandbox title="Live example" collapsible=true
-
-[Click to open CodeSandbox.](https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1)
-
-<noscript>
-  Please enable JavaScript to view examples.
-</noscript>
-
-<template>
-  <iframe src="https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1" width="100%" height="1000px" style="max-height: 100vh"></iframe>
-</template>
-
-```
 
 <details>
 <summary>CodeSandbox Source</summary>


### PR DESCRIPTION
This PR adds custom admonition for `mdbook-admonish`, addressing the #1 

It can be used in the book like this:

```md
    ```admonish sandbox title="Live example" collapsible=true
    [Click to open CodeSandbox.](https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1)
    <noscript>
      Please enable JavaScript to view examples.
    </noscript>
    <template>
      <iframe src="https://codesandbox.io/p/sandbox/1-basic-component-3d74p3?file=%2Fsrc%2Fmain.rs%3A1%2C1" width="100%" height="1000px" style="max-height: 100vh"></iframe>
    </template>
    ```
```

There's also some styling of an expanded block making it wider on large screens.