### PR TITLE
fix: code example in dynamic styles

### DIFF
--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -95,8 +95,8 @@ Individual CSS properties can be directly updated with a similar `style:` syntax
                 // set the `style` attribute
                 style="position: absolute"
                 // and toggle individual CSS properties with `style:`
-                style:left=move || format!("{}px", x() + 100)
-                style:background-color=move || format!("rgb({}, {}, 100)", x(), 100)
+                style:left=move || format!("{}px", x.get() + 100)
+                style:background-color=move || format!("rgb({}, {}, 100)", x.get(), 100)
                 style:max-width="400px"
                 // Set a CSS variable for stylesheet use
                 style=("--columns", x)


### PR DESCRIPTION
given 
```rust
let (x, set_x) = create_signal(0);
```
x is of type `ReadSignal<i32>`, a read-only reference to the signal value. the current example calls `x`, rather than `x.get()` (the `get` method to retrieve the value of the signal) yielding the following error:

`expected function, found ReadSignal<{integer}>`

this pr adds the `.get()` method call on applicable instances of `x`. 
