### PR TITLE
Add notice to ensure wasm target is installed under setup-page for SSR apps

### DIFF
--- a/src/ssr/21_cargo_leptos.md
+++ b/src/ssr/21_cargo_leptos.md
@@ -24,6 +24,11 @@ or
 cargo leptos new --git leptos-rs/start-axum
 ```
 
+Make sure you've added the wasm32-unknown-unknown target so that Rust can compile your code to WebAssembly to run in the browser.
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
 Now `cd` into the directory you’ve created and run
 
 ```bash


### PR DESCRIPTION
Right now the setup/get started for CSR setups includes a line of "remember to add wasm target". While the SSR setup instructions do not. 

Logically speaking if you use the book from one end to the other, you would have added it in CSR and thus don't need it in SSR. But for users that know they want to make an SSR app, they might skip the CSR setup (like me), and go straight to SSR, and then running the commands there will give a large amount of errors: 
```rust
error[E0425]: cannot find function, tuple struct or tuple variant `Some` in this scope
    --> /home/fm/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hashbrown-0.14.5/src/map.rs:4915:29
     |
4915 |             Some((_, v)) => Some(v),
     |                             ^^^^ not found in this scope
```

I missed the step in CSR setup, and forgot about the obvious part of making a webapp require the wasm target to be installed, so I had to search on your discord before I found the answer. (My first time doing a web target with rust)

So I think repeating that small bit of instruction with the same wording as CSR setup, is worth it on SSR setup page :)

Current SSR setup page:
![image](https://github.com/leptos-rs/book/assets/7889925/265a080b-9535-476a-8fd9-a740cf09eff3)


