### PR TITLE
Fix typo: change 'memoizes' to 'memorizes' in 06_control_flow.md

### DIFF
--- a/src/view/06_control_flow.md
+++ b/src/view/06_control_flow.md
@@ -206,7 +206,7 @@ view! {
 }
 ```
 
-`<Show/>` memoizes the `when` condition, so it only renders its `<Small/>` once,
+`<Show/>` memorizes the `when` condition, so it only renders its `<Small/>` once,
 continuing to show the same component until `value` is greater than five;
 then it renders `<Big/>` once, continuing to show it indefinitely or until `value`
 goes below five and then renders `<Small/>` again.


### PR DESCRIPTION
**Description**

Hello, this is my first time contributing to open-source, and I'm excited to be able to help out!

I found a typo in the 06_control_flow and have submitted a pull request to fix it. I've changed the word 'memoizes' to 'memorizes'.

**Additional Information**

Please let me know if there's anything I can do to improve the changes or if there are any additional steps I need to take. I'm eager to learn and contribute more to the project.

Thank you for your time and consideration!