### PR TITLE
updated input type and fixed type-o

### DIFF
--- a/src/view/05_forms.md
+++ b/src/view/05_forms.md
@@ -49,7 +49,7 @@ view! {
 >
 > One odd quirk is that there is a distinction between HTML attributes and DOM element properties, i.e., between something called an “attribute” which is parsed from HTML and can be set on a DOM element with `.setAttribute()`, and something called a “property” which is a field of the JavaScript class representation of that parsed HTML element.
 >
-> In the case of an `<input value=...>`, setting the `value` _attribute_ is defined as setting the initial value for the input, and setting `value` _property_ sets its current value. It maybe easiest to understand this by opening `about:blank` and running the following JavaScript in the browser console, line by line:
+> In the case of an `<input value=...>`, setting the `value` _attribute_ is defined as setting the initial value for the input, and setting `value` _property_ sets its current value. It may be easiest to understand this by opening `about:blank` and running the following JavaScript in the browser console, line by line:
 >
 > ```js
 > // create an input and append it to the DOM

--- a/src/view/07_errors.md
+++ b/src/view/07_errors.md
@@ -69,7 +69,7 @@ fn NumericInput() -> impl IntoView {
         <h1>"Error Handling"</h1>
         <label>
             "Type a number (or something that's not a number!)"
-            <input type="number" on:input=on_input/>
+            <input type="text" on:input=on_input/>
             <ErrorBoundary
                 // the fallback receives a signal containing current errors
                 fallback=|errors| view! {
@@ -140,7 +140,7 @@ fn App() -> impl IntoView {
         <h1>"Error Handling"</h1>
         <label>
             "Type a number (or something that's not a number!)"
-            <input type="number" on:input=on_input/>
+            <input type="text" on:input=on_input/>
             // If an `Err(_) had been rendered inside the <ErrorBoundary/>,
             // the fallback will be displayed. Otherwise, the children of the
             // <ErrorBoundary/> will be displayed.


### PR DESCRIPTION
- input type in Error Handling prevented typing non-numbers and seeing the error

- (This is nit-picky) changed "It maybe easiest..." to "It may be easiest..." according to https://dictionary.cambridge.org/us/grammar/british-grammar/maybe-or-may-be
