### PR TITLE
Added a note to discourage using isize and usize

### DIFF
--- a/src/server/25_server_functions.md
+++ b/src/server/25_server_functions.md
@@ -135,6 +135,11 @@ will generate a server function endpoint at `/api/hello` that accepts a POST req
 
 Server functions are a cool technology, but it’s very important to remember. **Server functions are not magic; they’re syntax sugar for defining a public API.** The _body_ of a server function is never made public; it’s just part of your server binary. But the server function is a publicly accessible API endpoint, and its return value is just a JSON or similar blob. Do not return information from a server function unless it is public, or you've implemented proper security procedures. These procedures might include authenticating incoming requests, ensuring proper encryption, rate limiting access, and more.
 
+## An Important Note on Number Sizes
+
+When using Server functions, one should not use pointer-sized integer types such as `isize` and `usize` as the pointer-size of the server will probably be 64 bit, while the pointer-size in Wasm is 32 bit.
+This will lead to a deserialization error when the server sends a number which does not fit in 32 bits. Use fixed size types such as `i32` or `i64` to mitigate this problem.
+
 ## Integrating Server Functions with Leptos
 
 So far, everything I’ve said is actually framework agnostic. (And in fact, the Leptos server function crate has been integrated into Dioxus as well!) Server functions are simply a way of defining a function-like RPC call that leans on Web standards like HTTP requests and URL encoding.


### PR DESCRIPTION
I ran into an issue when using `isize` as the pointer length of Wasm is 32 bit and the one of my server is 64 bit.

It seems useful to add this note somewhere in the book, but I might not have found the best place to put it.