### PR TITLE
made the builder version the same as the runtime version, in the docker file

### DIFF
--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -19,7 +19,7 @@ The most popular way for people to deploy full-stack apps built with `cargo-lept
 
 ```dockerfile
 # Get started with a build env with Rust nightly
-FROM rustlang/rust:nightly-bullseye as builder
+FROM rustlang/rust:nightly-bookworm as builder
 
 # If you’re using stable, use this instead
 # FROM rust:1.74-bullseye as builder


### PR DESCRIPTION


when i tried to run this with different versions, it gave me a openssl not found error, but when i changed it it worked