### PR TITLE
Update README.md

### DIFF
--- a/src/getting_started/README.md
+++ b/src/getting_started/README.md
@@ -40,7 +40,7 @@ cargo install trunk
 And then create a basic Rust project
 
 ```bash
-cargo init leptos-tutorial
+cargo new leptos-tutorial
 ```
 
 `cd` into your new `leptos-tutorial` project and add `leptos` as a dependency


### PR DESCRIPTION
`cargo init` creates a Rust project in the *current* directory. This means the tutorial has a wrong order of operations for getting started.

It should be either:

1. `cargo new` and the line below says (currently correctly) "`cd` into your new directory", or
2. `mkdir leptos_tutorial`, `cd` into your new directory, then `cargo init`