### PR TITLE
Fix unclosed details element in 01_basic_component.md

### DIFF
--- a/src/view/01_basic_component.md
+++ b/src/view/01_basic_component.md
@@ -236,3 +236,4 @@ fn main() {
     leptos::mount_to_body(|| view! { <App/> })
 }
 ```
+</details>


### PR DESCRIPTION
This was breaking the printed version of the book (tested in Firefox and chromium).