### PR TITLE
fix(view): fix the variable name in src/view/02_dynamic_attributes.md

### DIFF
--- a/src/view/02_dynamic_attributes.md
+++ b/src/view/02_dynamic_attributes.md
@@ -92,7 +92,7 @@ class=(["button-20", "rounded"], move || count() % 2 == 1)
 Individual CSS properties can be directly updated with a similar `style:` syntax.
 
 ```rust
-let (x, set_x) = signal(0);
+let (count, set_count) = signal(0);
 
 view! {
     <button
@@ -102,11 +102,11 @@ view! {
         // set the `style` attribute
         style="position: absolute"
         // and toggle individual CSS properties with `style:`
-        style:left=move || format!("{}px", x.get() + 100)
-        style:background-color=move || format!("rgb({}, {}, 100)", x.get(), 100)
+        style:left=move || format!("{}px", count.get() + 100)
+        style:background-color=move || format!("rgb({}, {}, 100)", count.get(), 100)
         style:max-width="400px"
         // Set a CSS variable for stylesheet use
-        style=("--columns", move || x.get().to_string())
+        style=("--columns", move || count.get().to_string())
     >
         "Click to Move"
     </button>


### PR DESCRIPTION
Hi! I just started reading this book, and I think the variable name in this code snippet is wrong. The let statement uses `x` and `set_x` as variable names, but inside the view micro, `x`, and `set_count` are used.

This PR changed `x` to `count` and `set_x` to `set_count` to keep the consistency with previous code snippets.