### PR TITLE
Update cargo-leptos new project links

### DIFF
--- a/src/ssr/21_cargo_leptos.md
+++ b/src/ssr/21_cargo_leptos.md
@@ -14,14 +14,14 @@ And then to create a new project, you can run either
 
 ```bash
 # for an Actix template
-cargo leptos new --git leptos-rs/start
+cargo leptos new --git https://github.com/leptos-rs/start-actix
 ```
 
 or
 
 ```bash
 # for an Axum template
-cargo leptos new --git leptos-rs/start-axum
+cargo leptos new --git https://github.com/leptos-rs/start-axum
 ```
 
 Make sure you've added the wasm32-unknown-unknown target so that Rust can compile your code to WebAssembly to run in the browser.


### PR DESCRIPTION
When using `cargo leptos new --git leptos-rs/start`, cargo_generate assumes this is an abbreviation to the repository: `start-actix-0.6` and ends up cloning the 0.6 repo instead of the updated 0.7