### PR TITLE
Add clang to Dockerfile

### DIFF
--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -30,6 +30,10 @@ RUN wget https://github.com/cargo-bins/cargo-binstall/releases/latest/download/c
 RUN tar -xvf cargo-binstall-x86_64-unknown-linux-musl.tgz
 RUN cp cargo-binstall /usr/local/cargo/bin
 
+# Install required tools
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends clang
+
 # Install cargo-leptos
 RUN cargo binstall cargo-leptos -y
 


### PR DESCRIPTION
Hello, with `Leptos v0.6` I was using the `Dockerfile` from the book. After updating and trying to deploy (to fly.io), I'm getting the following error:

```bash
30.61 warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang` installed?
30.61 warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang` installed?
30.61 warning: ring@0.17.8: Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang` installed?
30.61 error: failed to run custom build command for `ring v0.17.8`
30.61 
30.61 Caused by:
30.61   process didn't exit successfully: `/app/target/front/release/build/ring-3ec6e24d0db4eb47/build-script-build` (exit status: 1)
30.61   --- stdout
30.61   cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
30.61   cargo:rustc-env=RING_CORE_PREFIX=ring_core_0_17_8_
30.61   OPT_LEVEL = Some(z)
30.61   OUT_DIR = Some(/app/target/front/wasm32-unknown-unknown/release/build/ring-19f6c529f56eefd4/out)
30.61   TARGET = Some(wasm32-unknown-unknown)
30.61   HOST = Some(x86_64-unknown-linux-gnu)
30.61   cargo:rerun-if-env-changed=CC_wasm32-unknown-unknown
30.61   CC_wasm32-unknown-unknown = None
30.61   cargo:rerun-if-env-changed=CC_wasm32_unknown_unknown
30.61   CC_wasm32_unknown_unknown = None
30.61   cargo:rerun-if-env-changed=TARGET_CC
30.61   TARGET_CC = None
30.61   cargo:rerun-if-env-changed=CC
30.61   CC = None
30.61   cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
30.61   cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang` installed?
30.61   RUSTC_WRAPPER = None
30.61   cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
30.61   CRATE_CC_NO_DEFAULTS = None
30.61   DEBUG = Some(false)
30.61   cargo:rerun-if-env-changed=CFLAGS_wasm32-unknown-unknown
30.61   CFLAGS_wasm32-unknown-unknown = None
30.61   cargo:rerun-if-env-changed=CFLAGS_wasm32_unknown_unknown
30.61   CFLAGS_wasm32_unknown_unknown = None
30.61   cargo:rerun-if-env-changed=TARGET_CFLAGS
30.61   TARGET_CFLAGS = None
30.61   cargo:rerun-if-env-changed=CFLAGS
30.61   CFLAGS = None
30.61   CARGO_ENCODED_RUSTFLAGS = Some()
30.61   cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang` installed?
30.61   cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `clang` installed?
30.61 
30.61   --- stderr
30.61 
30.61 
30.61   error occurred in cc-rs: Failed to find tool. Is `clang` installed?
```

This PR adds the clang package that prevents the error :

```bash
# Install required tools
RUN apt-get update -y \
  && apt-get install -y --no-install-recommends clang
```