### PR TITLE
Fix spelling

### DIFF
--- a/src/async/README.md
+++ b/src/async/README.md
@@ -6,6 +6,6 @@ subset of what web applications do. In particular, most web apps have to deal wi
 
 Asynchronous data is notoriously hard to integrate with the synchronous parts of your code because of problems of “function coloring.”
 
-In the following chapters, we’ll see a few reactive primitives for working with async data. But it’s important to note at the very beginning: If you just want to do some asynchronous work, Leptos provides a cross-platform [`spawn_local`](https://docs.rs/leptos/latest/leptos/task/fn.spawn_local.html) function that makes it easy to run a `Future`. If one of the primitives that’s discussd in the rest of this section doesn’t seem to do what you want, consider combining `spawn_local` with setting a signal.
+In the following chapters, we’ll see a few reactive primitives for working with async data. But it’s important to note at the very beginning: If you just want to do some asynchronous work, Leptos provides a cross-platform [`spawn_local`](https://docs.rs/leptos/latest/leptos/task/fn.spawn_local.html) function that makes it easy to run a `Future`. If one of the primitives discussed in the rest of this section doesn’t seem to do what you want, consider combining `spawn_local` with setting a signal.
 
 While the primitives to come are very useful, and even necessary in some cases, people sometimes run into situations in which they really just need to spawn a task and wait for it to finish before doing something else. Use `spawn_local` in those situations!


### PR DESCRIPTION
### Changes made:
1. **"discussd"** → **"discussed"**: Corrected the spelling mistake.
2. (optional) Removed "that’s": It was unnecessary and made the sentence less concise.