### PR TITLE
Minor: Updated from tls1.2 to tls1.3

### DIFF
--- a/.github/workflows/publish_mdbook.yml
+++ b/.github/workflows/publish_mdbook.yml
@@ -21,10 +21,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-
   # Job: Build and Deploy to Pages
   build-and-deploy:
-
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -36,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install mdBook
         run: |
-          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+          curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
 

--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -88,7 +88,7 @@ RUN apk update && \
 
 RUN npm install -g sass
 
-RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/leptos-rs/cargo-leptos/releases/latest/download/cargo-leptos-installer.sh | sh
+RUN curl --proto '=https' --tlsv1.3 -LsSf https://github.com/leptos-rs/cargo-leptos/releases/latest/download/cargo-leptos-installer.sh | sh
 
 # Add the WASM target
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
Why should we drop 1.2?

"In TLS 1.2 and earlier versions, the use of ciphers with cryptographic weaknesses had posed potential security vulnerabilities"

<https://www.a10networks.com/glossary/key-differences-between-tls-1-2-and-tls-1-3/>

Also here is an independant article suggesting 1.2 should be deprecated in 2025

<https://mid.as/blog/proposal-to-drop-tls-1-2-support-in-early-2025/>

