### PR TITLE
Fixing nested route example.

### DIFF
--- a/src/router/17_nested_routing.md
+++ b/src/router/17_nested_routing.md
@@ -70,10 +70,10 @@ I actually need to add a fallback route
 
 ```rust
 <Routes>
-  <Route path="/users" view=Users>
+  <ParentRoute path="/users" view=Users>
     <Route path=":id" view=UserProfile/>
     <Route path="" view=NoUser/>
-  </Route>
+  </ParentRoute>
 </Routes>
 ```
 


### PR DESCRIPTION
The nested route example nested two Route tags instead of a ParentRoute and Route.  This should be the correct usage.