### PR TITLE
Update ssr.md to avoid Cargo.lock version issue

### DIFF
--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -22,7 +22,7 @@ The most popular way for people to deploy full-stack apps built with `cargo-lept
 FROM rustlang/rust:nightly-bullseye as builder
 
 # If you’re using stable, use this instead
-# FROM rust:1.74-bullseye as builder
+# FROM rust:1.86-bullseye as builder
 
 # Install cargo-binstall, which makes it easier to install other
 # cargo extensions like cargo-leptos


### PR DESCRIPTION
Lockfile v4 was stabilized in Rust `1.78.0`. Because of that, when using a stable Rust version from before that version, as here, Cargo.lock version mismatches can arise. This corrects that issue by using the latest stable Rust as the builder.