### PR TITLE
Added syntax highlighting to example in iteration chapter

### DIFF
--- a/src/view/04_iteration.md
+++ b/src/view/04_iteration.md
@@ -60,7 +60,7 @@ Note here that instead of calling `signal()` to get a tuple with a reader and a 
 here we use `RwSignal::new()` to get a single, read-write signal. This is just more convenient
 for a situation where we’d otherwise be passing the tuples around.
 
-```
+```rust
 // each item manages a reactive view
 // but the list itself will never change
 let counter_buttons = counters


### PR DESCRIPTION
It was missing the tag for rust syntax highlighting in the markdown, so I added it.