### PR TITLE
Bugfix in Chapter 6.1

### DIFF
--- a/src/async/10_resources.md
+++ b/src/async/10_resources.md
@@ -1,6 +1,6 @@
 # Loading Data with Resources
 
-Resources are reactive wrappers for asynchronous tasks, which allow you to integrate an asynchronous `Future` into the synchronous reactive system. 
+Resources are reactive wrappers for asynchronous tasks, which allow you to integrate an asynchronous `Future` into the synchronous reactive system.
 
 They effectively allow you to load some async data, and then reactively access it either synchronously or asynchronously. You can `.await` a resource like an ordinary `Future`, and this will track it. But you can also access a resource with `.get()` and other signal access methods, as if a resource were a signal that returns `Some(T)` if it has resolved, and `None` if it’s still pending.
 
@@ -36,7 +36,7 @@ This API is slightly different. `Resource::new()` takes two functions as its arg
 
 Unlike a `LocalResource`, a `Resource` serializes its value from the server to the client. Then, on the client, when first loading the page, the initial value will be deserialized rather than the async task running again. This is extremely important and very useful: It means that rather than waiting for the client WASM bundle to load and begin running the application, data loading begins on the server. (There will be more to say about this in later chapters.)
 
-This is also why the API is split into two parts: signals in the *source* function are tracked, but signals in the *fetcher* are untracked, because this allows the resource to maintain reactivity without needing to run the fetcher again during initial hydration on the client.
+This is also why the API is split into two parts: signals in the _source_ function are tracked, but signals in the _fetcher_ are untracked, because this allows the resource to maintain reactivity without needing to run the fetcher again during initial hydration on the client.
 
 Here’s the same example, using `Resource` instead of `LocalResource`
 
@@ -48,11 +48,11 @@ let (count, set_count) = signal(0);
 let async_data = Resource::new(
     move || count.get(),
     // every time `count` changes, this will run
-    |count| load_data(count) 
+    |count| load_data(count)
 );
 ```
 
-Resources also provide a `refetch()` method that allows you to manually reload the data (for example, in response to a button click). 
+Resources also provide a `refetch()` method that allows you to manually reload the data (for example, in response to a button click).
 
 To create a resource that simply runs once, you can use `OnceResource`, which simply takes a `Future`, and adds some optimizations that come from knowing it will only load once.
 
@@ -107,56 +107,6 @@ pub fn App() -> impl IntoView {
     let stable = LocalResource::new(|| load_data(1));
 
     // we can access the resource values with .get()
-use gloo_timers::future::TimeoutFuture;
-use leptos::prelude::*;
-
-// Here we define an async function
-// This could be anything: a network request, database read, etc.
-// Here, we just multiply a number by 10
-async fn load_data(value: i32) -> i32 {
-    // fake a one-second delay
-    TimeoutFuture::new(1_000).await;
-    value * 10
-}
-
-#[component]
-pub fn App() -> impl IntoView {
-    // this count is our synchronous, local state
-    let (count, set_count) = signal(0);
-
-    // tracks `count`, and reloads by calling `load_data`
-    // whenever it changes
-    let async_data = LocalResource::new(move || load_data(count.get()));
-
-    // a resource will only load once if it doesn't read any reactive data
-    let stable = LocalResource::new(|| load_data(1));
-
-    // we can access the resource values with .get()
-use gloo_timers::future::TimeoutFuture;
-use leptos::prelude::*;
-
-// Here we define an async function
-// This could be anything: a network request, database read, etc.
-// Here, we just multiply a number by 10
-async fn load_data(value: i32) -> i32 {
-    // fake a one-second delay
-    TimeoutFuture::new(1_000).await;
-    value * 10
-}
-
-#[component]
-pub fn App() -> impl IntoView {
-    // this count is our synchronous, local state
-    let (count, set_count) = signal(0);
-
-    // tracks `count`, and reloads by calling `load_data`
-    // whenever it changes
-    let async_data = LocalResource::new(move || load_data(count.get()));
-
-    // a resource will only load once if it doesn't read any reactive data
-    let stable = LocalResource::new(|| load_data(1));
-
-    // we can access the resource values with .get()
     // this will reactively return None before the Future has resolved
     // and update to Some(T) when it has resolved
     let async_result = move || {
@@ -185,8 +135,6 @@ pub fn App() -> impl IntoView {
             <br/>
         </p>
     }
-}
-
 fn main() {
     leptos::mount::mount_to_body(App)
 }


### PR DESCRIPTION
The code in the sandbox down below had some copy-pasta-issues. I fixed  them.

I apologize for various minor and meaningless additional corrections (`*text*` instead of `_text_`) or various line breaks, my editor is a bit more busy than necessary.