### PR TITLE
Set correct url for trunk template

### DIFF
--- a/src/view/README.md
+++ b/src/view/README.md
@@ -16,7 +16,7 @@ The `start-trunk` template requires that you have `Trunk` and `cargo-generate` i
 
 To use the template to set up your project, just run
 
-`cargo generate --git https://github.com/leptos-community/start-csr`
+`cargo generate --git https://github.com/leptos-rs/start-trunk`
 
 then run
 


### PR DESCRIPTION
`cargo generate` works but in browser I can see redirection to this url, so it might be correct version for repo url