### PR TITLE
Missing line in sandbox code in Chapter 6.4

### DIFF
--- a/src/async/13_actions.md
+++ b/src/async/13_actions.md
@@ -112,6 +112,7 @@ Now, there’s a chance this all seems a little over-complicated, or maybe too r
 use gloo_timers::future::TimeoutFuture;
 use leptos::{html::Input, prelude::*};
 use uuid::Uuid;
+use send_wrapper;
 
 // Here we define an async function
 // This could be anything: a network request, database read, etc.


### PR DESCRIPTION
use send_wrapper

Don't know how to fix the follwing in the sandbox, so I describe it here: In the `cargo.toml` add:
```
[dependencies]
# ....
uuid = { version = "1.17.0", features = ["v4", "js"] }
send_wrapper = "0.6.0"
```
The features "v4" and "js" (there are maybe more appropriate alternatives for "js", see compiler errors that occur without "js", I chose the first) are important.