### PR TITLE
fix(ssr.md): use bookworm instead of bullseye

### DIFF
--- a/src/deployment/ssr.md
+++ b/src/deployment/ssr.md
@@ -22,7 +22,7 @@ The most popular way for people to deploy full-stack apps built with `cargo-lept
 FROM rustlang/rust:nightly-bookworm as builder
 
 # If you’re using stable, use this instead
-# FROM rust:1.86-bullseye as builder
+# FROM rust:1.88-bookworm as builder
 
 # Install cargo-binstall, which makes it easier to install other
 # cargo extensions like cargo-leptos


### PR DESCRIPTION
Bullseye does not work anymore with newer versions of cargo leptos. glibc is too old in bullseye now, resulting in this error :

```
user $ cargo leptos
/usr/local/cargo/bin/cargo-leptos: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /usr/local/cargo/bin/cargo-leptos)
/usr/local/cargo/bin/cargo-leptos: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/cargo/bin/cargo-leptos)
/usr/local/cargo/bin/cargo-leptos: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /usr/local/cargo/bin/cargo-leptos)
/usr/local/cargo/bin/cargo-leptos: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/cargo/bin/cargo-leptos)
command returned a non-zero code: 1
```