### PR TITLE
docs: list clarity and grouping

### DIFF
--- a/src/01_introduction.md
+++ b/src/01_introduction.md
@@ -7,7 +7,7 @@ full-stack application with server-side rendering and hydration.
 
 The guide doesn’t assume you know anything about fine-grained reactivity or the
 details of modern Web frameworks. It does assume you are familiar with the Rust
-programming language, HTML, CSS, and the DOM and basic Web APIs.
+programming language, HTML, CSS, the DOM, and basic Web APIs.
 
 Leptos is most similar to frameworks like [Solid](https://www.solidjs.com) (JavaScript)
 and [Sycamore](https://sycamore-rs.netlify.app/) (Rust). There are some similarities


### PR DESCRIPTION
Started reading the book and the double use of "and" when listing prerequisites was clunky and awkward