### PR TITLE
Note about extracting an attribute spread

### DIFF
--- a/src/view/03_components.md
+++ b/src/view/03_components.md
@@ -441,34 +441,8 @@ fn spread_onto_component() -> impl Attribute {
     }
 }
 
-#[component]
-fn UseComponentThatTakesSpread() -> impl IntoView {
-    view! {
-        // attributes that are spread onto a component will be applied to *all* elements returned as part of
-        // the component's view. to apply attributes to a subset of the component, pass them via a component prop
-        <ComponentThatTakesSpread
-            // plain identifiers are for props
-            some_prop="foo"
-            another_prop=42
-
-            // the class:, style:, prop:, on: syntaxes work just as they do on elements
-            class:foo=true
-            style:font-weight="bold"
-            prop:cool=42
-            on:click=move |_| alert("clicked ComponentThatTakesSpread")
-
-            // to pass a plain HTML attribute, prefix it with attr:
-            attr:id="foo"
-
-            // or, if you want to include multiple attributes, rather than prefixing each with
-            // attr:, you can separate them from component props with the spread {..}
-            {..} // everything after this is treated as an HTML attribute
-            title="ooh, a title!"
-
-            // we can add the whole list of attributes defined above
-            {..spread_onto_component()}
-        />
-    }
+view!{
+    <SomeComponent {..spread_onto_component()} />
 }
 ```
 ``````

--- a/src/view/03_components.md
+++ b/src/view/03_components.md
@@ -429,6 +429,50 @@ view! {
 }
 ```
 
+``````admonish note
+If you would like to extract the attributes into the function so you can use it in multiple components, you can do so by implementing a function that returns `impl Attribute`.
+
+That would make example above look like this:
+
+```rust
+fn spread_onto_component() -> impl Attribute {
+    view!{
+        <{..} aria-label="a component with attribute spreading">
+    }
+}
+
+#[component]
+fn UseComponentThatTakesSpread() -> impl IntoView {
+    view! {
+        // attributes that are spread onto a component will be applied to *all* elements returned as part of
+        // the component's view. to apply attributes to a subset of the component, pass them via a component prop
+        <ComponentThatTakesSpread
+            // plain identifiers are for props
+            some_prop="foo"
+            another_prop=42
+
+            // the class:, style:, prop:, on: syntaxes work just as they do on elements
+            class:foo=true
+            style:font-weight="bold"
+            prop:cool=42
+            on:click=move |_| alert("clicked ComponentThatTakesSpread")
+
+            // to pass a plain HTML attribute, prefix it with attr:
+            attr:id="foo"
+
+            // or, if you want to include multiple attributes, rather than prefixing each with
+            // attr:, you can separate them from component props with the spread {..}
+            {..} // everything after this is treated as an HTML attribute
+            title="ooh, a title!"
+
+            // we can add the whole list of attributes defined above
+            {..spread_onto_component()}
+        />
+    }
+}
+```
+``````
+
 See the [`spread` example](https://github.com/leptos-rs/leptos/blob/main/examples/spread/src/lib.rs) for more examples.
 
 ```admonish sandbox title="Live example" collapsible=true


### PR DESCRIPTION
I've added a note which states how to extract the attribute spread into the function.

This is related to the issue I've raised in the `leptos` repo `https://github.com/leptos-rs/leptos/issues/4196`.