### PR TITLE
Minor code fix in example

### DIFF
--- a/src/view/03_components.md
+++ b/src/view/03_components.md
@@ -437,7 +437,7 @@ That would make the example above look like this:
 ```rust
 fn spread_onto_component() -> impl Attribute {
     view!{
-        <{..} aria-label="a component with attribute spreading">
+        <{..} aria-label="a component with attribute spreading"/>
     }
 }
 


### PR DESCRIPTION
An example `view!` tag was not closed, creating a compilation error.