### PR TITLE
Fix Neovim documentation

### DIFF
--- a/src/getting_started/leptos_dx.md
+++ b/src/getting_started/leptos_dx.md
@@ -56,26 +56,26 @@ VSCode with cargo-leptos `settings.json`:
 "rust-analyzer.cargo.features": ["ssr"]
 ```
 
-neovim with lspconfig:
+Neovim:
 
 ```lua
-require('lspconfig').rust_analyzer.setup {
+vim.lsp.config('rust_analyzer', {
   -- Other Configs ...
   settings = {
     ["rust-analyzer"] = {
       -- Other Settings ...
       procMacro = {
         ignored = {
-            leptos_macro = {
-                -- optional: --
-                -- "component",
-                "server",
-            },
+          leptos_macro = {
+            -- optional: --
+            -- "component",
+            "server",
+          },
         },
       },
     },
   }
-}
+})
 ```
 
 Helix, in `.helix/languages.toml`:
@@ -137,18 +137,17 @@ VSCode, in `settings.json`:
 }
 ```
 
-neovim with lspconfig, in `init.lua` or `lspconfig.lua`:
+Neovim, in `init.lua`:
 ```lua
-require('lspconfig').rust_analyzer.setup {
-  -- Enable all features for rust-analyzer.
+vim.lsp.config('rust_analyzer', {
   settings = {
     ["rust-analyzer"] = {
-    cargo = {
-      allFeatures = true,  -- Enable all features
+      cargo = {
+        features = "all", -- Enable all features
       },
     },
   }
-}
+})
 
 ```
 helix, in `.helix/languages.toml` or per project in `.helix/config.toml`:


### PR DESCRIPTION
Neovim 0.11 introduced the `vim.lsp.config` function for configuring LSP clients[<sup>1</sup>](#ref-1), and so the `nvim-lspconfig` became just a repository for LSP configuration, deprecating everything else[<sup>2</sup>](#ref-2). I thus updated the Neovim examples to invoke `vim.lsp.config` instead of the deprecated `require'lspconfig'.….setup{}`. I also removed references from `lspconfig` since it's technically not required anymore (or are we assuming the user does not know how to configure LSP in general?) and capitalized "neovim" to "Neovim" since that's how it's referred to in <https://neovim.io/>.

I also changed the `cargo.allFeatures = true` to `cargo.features = "all"` since that is also the new way of doing it[<sup>3</sup>](#ref-3)[<sup>4</sup>](#ref-4). This change could probably be applied to the other examples as well.

<ol>
  <li id="ref-1"> <a href="https://neovim.io/doc/user/news-0.11.html">https://neovim.io/doc/user/news-0.11.html</a> </li>
  <li id="ref-2"> <a href="https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#important-%EF%B8%8F">https://github.com/neovim/nvim-lspconfig?tab=readme-ov-file#important-%EF%B8%8F</a> </li>
  <li id="ref-3"> <a href="https://github.com/rust-lang/rust-analyzer/pull/12010">https://github.com/rust-lang/rust-analyzer/pull/12010</a> </li>
  <li id="ref-4"> <a href="https://rust-analyzer.github.io/book/configuration.html#cargo.features">https://rust-analyzer.github.io/book/configuration.html#cargo.features</a> </li>
</ol>