### PR TITLE
add builder syntax equivalent

### DIFF
--- a/src/view/01_basic_component.md
+++ b/src/view/01_basic_component.md
@@ -44,6 +44,28 @@ fn App() -> impl IntoView {
 }
 ```
 
+~~~admonish title="Builder syntax", collapsible=true
+  ```rust
+  use leptos::{
+    IntoView, component, ev,
+    html::{ElementChild, button, p},
+    prelude::{Get, OnAttribute, Set},
+    reactive::signal::signal,
+  };
+
+  #[component]
+  fn App() -> impl IntoView {
+      let (count, set_count) = signal(0);
+      (
+          button().child(move || format!("Click me: {}", count.get())).on(ev::click, move |_| {
+              set_count.set(3);
+          }),
+          p().child(move || format!("Double count: {}", count.get() * 2)),
+      )
+  }
+  ```
+~~~
+
 ## Importing the Prelude
 
 ```rust


### PR DESCRIPTION
i like to add builder syntax equivalent to example codes in book
since i am new to github, for start i added only one example in this pull request 
if this pr is okay, i will add equivalent to other example codes