### PR TITLE
Update on enabling features in Rust-Analyzer for VSCode

### DIFF
--- a/src/getting_started/leptos_dx.md
+++ b/src/getting_started/leptos_dx.md
@@ -133,7 +133,7 @@ How to enable these features varies by your IDE, we've listed some common ones b
 VSCode, in `settings.json`:
 ```json
 {
-  "rust-analyzer.cargo.allFeatures": true,  // Enable all features
+  "rust-analyzer.cargo.features": "all",  // Enable all features
 }
 ```
 


### PR DESCRIPTION
This MR makes a slight update on [chapter 2.1, section 3](https://book.leptos.dev/getting_started/leptos_dx.html#3-enable-features-in-rust-analyzer-for-your-editor-optional) on setting a key in VSCode's `settings.json` for enabling all features in rust-analyzer for Leptos.

Closes #240 