### PR TITLE
feat: add spa routing setup command

### DIFF
--- a/src/deployment/csr.md
+++ b/src/deployment/csr.md
@@ -86,6 +86,10 @@ Deploying a Leptos CSR app to Github pages is a simple affair. First, go to your
             # will obviously return error 404 not found.
             run: ./trunk build --release --public-url "${GITHUB_REPOSITORY#*/}"
 
+          # Copy index.html to 404.html for SPA routing
+          # Will allow routing to work if client enters from any route
+          # - name: Copy index.html to 404.html
+          #   run: cp dist/index.html dist/404.html
 
           # Deploy to gh-pages branch
           # - name: Deploy 🚀


### PR DESCRIPTION
When hosting Leptos CSR on Github Pages, to get routing working correctly, the 404.html will need to allow Leptos Router to handle requests.

A pretty straightforward way to do this is to simply copy index.html to 404.html. This change adds a Github Action step that does that automatically.