### PR TITLE
Update 04_iteration.md, fix Rust build error

### DIFF
--- a/src/view/04_iteration.md
+++ b/src/view/04_iteration.md
@@ -317,7 +317,7 @@ struct Counter {
     each=move || counters.get() // Same as <For/>
     key=|counter| counter.id    // Same as <For/>
     // Provides the index as a signal and the child T
-    children={move |index: ReadSignal<usize>, counter: Counter| {
+    children={move |index, counter| {
         view! {
             <button>{move || index.get()} ". Value: " {move || counter.count.get()}</button>
         }


### PR DESCRIPTION
With the following type annotation, "trunk serve --open" always fail the building, this is quite strange. It can be fixed by simply removing it.

|index: ReadSignal<usize>, counter: Counter|
->|index, counter|


At the same time, I see the following example has two issues.
1. create_signal -> signal
2. |index: ReadSignal<usize>, counter: Counter|, build failure

https://docs.rs/leptos/latest/leptos/control_flow/fn.ForEnumerate.html

If possible, could you share me more why type annotation wasn't accepted in running "trunk serve --open"? Perhaps the real fix should come from the other side?

Thanks!