### PR TITLE
fix: update links to trunk docs

### DIFF
--- a/src/deployment/sub_path.md
+++ b/src/deployment/sub_path.md
@@ -39,4 +39,4 @@ If you are using server functions, they will default to sending requests to `/`.
 
 ## Trunk configuration
 
-If you’re using client-side rendering with Trunk, [consult the Trunk docs](https://trunkrs.dev/assets/#directives) on how to set the public URL via `--public-url`.
+If you’re using client-side rendering with Trunk, [consult the Trunk docs](https://trunk-rs.github.io/trunk/guide/assets/index.html#directives) on how to set the public URL via `--public-url`.

--- a/src/interlude_styling.md
+++ b/src/interlude_styling.md
@@ -12,7 +12,7 @@ Here are a few different approaches to styling your Leptos app, starting with pl
 
 `trunk` can be used to bundle CSS files and images with your site. To do this, you can add them as Trunk assets by defining them in your `index.html` in the `<head>`. For example, to add a CSS file located at `style.css` you can add the tag `<link data-trunk rel="css" href="./style.css"/>`.
 
-You can find more information in the Trunk documentation for [assets](https://trunkrs.dev/assets/).
+You can find more information in the Trunk documentation for [assets](https://trunk-rs.github.io/trunk/guide/assets/index.html).
 
 ### Server-Side Rendering with `cargo-leptos`
 


### PR DESCRIPTION
this pr updates links to the trunk-rs docs. the old domain `trunkrs.dev` now leads to a turkish gambling site. im guessing their domain expired.