### PR TITLE
Fix: Add `--locked` flag when installing `trunk`

### DIFF
--- a/src/getting_started/README.md
+++ b/src/getting_started/README.md
@@ -33,7 +33,7 @@ First up, make sure Rust is installed and up-to-date ([see here if you need inst
 If you don’t have it installed already, you can install the "Trunk" tool for running Leptos CSR sites by running the following on the command-line:
 
 ```bash
-cargo install trunk
+cargo install --locked trunk
 ```
 
 And then create a basic Rust project


### PR DESCRIPTION
I am running linux. When following the [hello world](https://book.leptos.dev/getting_started/index.html#hello-world-getting-set-up-for-leptos-csr-development) guide, building [trunk](https://trunk-rs.github.io/trunk/) threw errosr.

So, I went to their site and found they use recommend using `--locked` flag. 

I did that and it built without any problems.